### PR TITLE
[matura_pro_ai] Add skill scoring and timer

### DIFF
--- a/matura_pro_ai/lib/controllers/test/test_controller.dart
+++ b/matura_pro_ai/lib/controllers/test/test_controller.dart
@@ -4,11 +4,17 @@ import '../../models/test/test_result.dart';
 import '../../models/test/test_progress.dart';
 import '../../models/tags_and_topics_results.dart';
 
-class TestController 
+class TestController
 {
   int _currentPartID = 0;
   Test test;
   final List<TestPartController> _partControllers = [];
+
+  static const Map<String, String> _partSkillMap = {
+    'ROZUMIENIE TEKSTÓW PISANYCH': 'reading',
+    'ZNAJOMOŚĆ ŚRODKÓW JĘZYKOWYCH': 'grammar',
+    'ROZUMIENIE ZE SŁUCHU': 'listening',
+  };
 
   TestController(this.test) 
   {
@@ -51,7 +57,13 @@ class TestController
 
     for (int i = 0; i <= currentPartID; i++) {
       results.partNames.add(parts[i].name);
-      results.partResults.add(parts[i].evaluate());
+      final partScore = parts[i].evaluate();
+      results.partResults.add(partScore);
+
+      final skill = _partSkillMap[parts[i].name];
+      if (skill != null) {
+        results.skillBreakdown[skill] = partScore;
+      }
 
       for (final question in parts[i].questions) {
         double score = question.evaluate();

--- a/matura_pro_ai/lib/models/test/test_result.dart
+++ b/matura_pro_ai/lib/models/test/test_result.dart
@@ -1,12 +1,32 @@
-class TestResult 
+class TestResult
 {
   final String name;
   List<String> partNames = [];
   List<double> partResults = [];
+  final Map<String, double> skillBreakdown = {};
 
   TestResult(this.name);
 
-  double get average => partResults.isEmpty
-      ? 0
-      : partResults.reduce((a, b) => a + b) / partResults.length;
+  static const Map<String, double> _defaultWeights = {
+    'reading': 0.33,
+    'grammar': 0.34,
+    'listening': 0.33,
+  };
+
+  double weightedScore({Map<String, double>? weights}) {
+    final w = weights ?? _defaultWeights;
+    if (skillBreakdown.isEmpty) {
+      return partResults.isEmpty
+          ? 0
+          : partResults.reduce((a, b) => a + b) / partResults.length;
+    }
+    double score = 0;
+    for (final entry in skillBreakdown.entries) {
+      final weight = w[entry.key] ?? 0;
+      score += entry.value * weight;
+    }
+    return score;
+  }
+
+  double get average => weightedScore();
 }

--- a/matura_pro_ai/lib/views/stats/user_statistics_page.dart
+++ b/matura_pro_ai/lib/views/stats/user_statistics_page.dart
@@ -49,6 +49,18 @@ class UserStatisticsPage extends ConsumerWidget {
                 );
               },
             ),
+            if (testResult.skillBreakdown.isNotEmpty) ...[
+              const Divider(height: 24),
+              ...testResult.skillBreakdown.entries.map(
+                (e) => ListTile(
+                  title: Text(e.key),
+                  trailing: Text(
+                    "${(e.value * 100).toStringAsFixed(1)}%",
+                    style: theme.textTheme.bodyLarge,
+                  ),
+                ),
+              ),
+            ],
             const SizedBox(height: 12),
             Center(
               child: SpeedometerGauge(

--- a/matura_pro_ai/lib/widgets/test/test_page.dart
+++ b/matura_pro_ai/lib/widgets/test/test_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/gestures.dart';
+import 'dart:async';
 
 import '../../core/constants.dart';
 import '../../core/theme_defaults.dart';
@@ -35,6 +36,15 @@ class _TestPageState extends State<TestPage> {
   final ScrollController _scrollController = ScrollController();
 
   QuestionController? _currentQuestionController;
+  static const Map<String, int> _partDurations = {
+    'ROZUMIENIE TEKSTÓW PISANYCH': 300,
+    'ZNAJOMOŚĆ ŚRODKÓW JĘZYKOWYCH': 300,
+    'ROZUMIENIE ZE SŁUCHU': 300,
+  };
+
+  int _secondsRemaining = 0;
+  int _currentDuration = 0;
+  Timer? _timer;
 
   @override
   void initState() {
@@ -44,20 +54,43 @@ class _TestPageState extends State<TestPage> {
     });
   }
 
+  void _startTimer() {
+    final name = widget.testController.currentPart.name;
+    _currentDuration = _partDurations[name] ?? 300;
+    _secondsRemaining = _currentDuration;
+    _timer?.cancel();
+    _timer = Timer.periodic(const Duration(seconds: 1), (t) {
+      if (!mounted) return;
+      if (_secondsRemaining <= 0) {
+        t.cancel();
+        setState(() {});
+        return;
+      }
+      setState(() {
+        _secondsRemaining--;
+      });
+    });
+  }
+
   @override
   void dispose() {
     _scrollController.dispose();
+    _timer?.cancel();
     super.dispose();
   }
 
   void _serveQuestion() async {
     final part = widget.testController.currentPart;
     final controller = part.currentQuestion;
-    
+
     if (controller == null) {
       widget.testController.nextPart();
       _serveQuestion();
       return;
+    }
+
+    if (part.currentIndex == 0) {
+      _startTimer();
     }
 
     setState(() {
@@ -97,16 +130,34 @@ class _TestPageState extends State<TestPage> {
     if (part.isLastQuestion) {
       bool shouldContinue = await widget.onPartFinished(part);
       if (!shouldContinue || widget.testController.isLastPart) {
+        _timer?.cancel();
         await widget.onTestEnded();
         return;
       }
 
+      _timer?.cancel();
       widget.testController.nextPart();
     } else {
       part.nextQuestion();
     }
 
     _serveQuestion();
+  }
+
+  Widget _buildTimerWidget(BuildContext context) {
+    if (_currentDuration == 0) return const SizedBox.shrink();
+    final progress =
+        _currentDuration == 0 ? 0.0 : _secondsRemaining / _currentDuration;
+    final minutes = (_secondsRemaining ~/ 60).toString().padLeft(2, '0');
+    final seconds = (_secondsRemaining % 60).toString().padLeft(2, '0');
+    final color = progress < 0.2 ? Colors.red : Theme.of(context).colorScheme.primary;
+    return Column(
+      children: [
+        LinearProgressIndicator(value: progress, color: color),
+        const SizedBox(height: 4),
+        Text('$minutes:$seconds'),
+      ],
+    );
   }
 
   @override
@@ -134,9 +185,9 @@ class _TestPageState extends State<TestPage> {
                     child: Text(widget.label,
                         style: theme.textTheme.titleLarge,
                         textAlign: TextAlign.center)),
-                const SizedBox(
-                  height: 64,
-                ),
+                const SizedBox(height: 16),
+                _buildTimerWidget(context),
+                const SizedBox(height: 48),
                 Padding(
                   padding: const EdgeInsets.all(ThemeDefaults.padding),
                   child: _buildQuestionWidget(),


### PR DESCRIPTION
## Summary
- add `skillBreakdown` and weighting to `TestResult`
- compute skill-based scores in `TestController`
- display skill breakdown in statistics page
- implement per-section countdown timer on `TestPage`

## Testing
- `flutter analyze`
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_6875826b47c8832e9e04e19a4ed7dec0