### PR TITLE
[matura_pro_ai] Enable audio replay and add waveform animation

### DIFF
--- a/matura_pro_ai/lib/core/constants.dart
+++ b/matura_pro_ai/lib/core/constants.dart
@@ -55,6 +55,7 @@ class AppStrings {
   static const String playAudio = 'Odtwórz';
   static const String pauseAudio = 'Pauza';
   static const String resumeAudio = 'Wznów';
+  static const String replayOnce = 'Powtórz nagranie';
 
   static const String categories = 'Kategorie';
   static const String categoriesIncomplete = 'Please categorize all items';


### PR DESCRIPTION
## Summary
- allow repeating audio once in `ListeningQuestionContent`
- add pulsing waveform while audio plays
- add option label to `AppStrings`

## Testing
- `flutter pub get`
- `flutter analyze`
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_68759978e50c832ea2fbd6a2029663b3